### PR TITLE
syn v2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ proc-macro = true
 convert_case = "0.6.0"
 proc-macro2 = "1.0.37"
 quote = "1.0.17"
-syn = { version = "1.0.91", features = ["full"] }
+syn = { version = "2.0.4", features = ["full"] }
 
 [dev-dependencies]
 anyhow = "1.0.57"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@ impl Parse for Nestruct {
         let ident = input.parse()?;
         let content;
         braced!(content in input);
-        let fields = content.parse_terminated(NestableField::parse)?;
+        let fields = content.parse_terminated(NestableField::parse, Token![,])?;
         Ok(Nestruct { attrs, ident, fields })
     }
 }
@@ -92,13 +92,13 @@ impl Parse for NestableField {
         } else if input.peek(token::Brace) {
             let content;
             braced!(content in input);
-            let fields = content.parse_terminated(NestableField::parse)?;
+            let fields = content.parse_terminated(NestableField::parse, Token![,])?;
             let nestruct = Nestruct { attrs: vec![], ident, fields };
             Ok(NestableField { field_attrs, name, fvtype: FVType::StructVariant { nestruct } })
         } else if input.peek(token::Paren) {
             let content;
             parenthesized!(content in input);
-            let types = content.parse_terminated(parse_simple_types)?;
+            let types = content.parse_terminated(parse_simple_types, Token![,])?;
             let fvtype = FVType::TupleVariant { types };
             Ok(NestableField { field_attrs, name, fvtype })
         } else {
@@ -116,7 +116,7 @@ impl NestableType {
         if input.peek(token::Brace) {
             let content;
             braced!(content in input);
-            let fields = content.parse_terminated(NestableField::parse)?;
+            let fields = content.parse_terminated(NestableField::parse, Token![,])?;
             Ok(Self::Nestruct(Nestruct { attrs, ident, fields }))
         } else {
             Ok(Self::Type(input.parse()?))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -203,7 +203,7 @@ fn generate_fields<'a>(
 }
 
 fn is_reset_attr(attr: &Attribute) -> bool {
-    if let Some(ident) = attr.path.get_ident() {
+    if let Some(ident) = attr.path().get_ident() {
         if ident == "nestruct" {
             if let Ok(arg) = attr.parse_args_with(Ident::parse_any) {
                 return arg == "reset";


### PR DESCRIPTION
- Update syn to version 2.0.4 with full features
- Update to use `path` function instead of `path` attribute
- Change to pass the argument
